### PR TITLE
Identifying the sequence element by a unique id

### DIFF
--- a/dynamic_stack_decider/src/dynamic_stack_decider/sequence_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/sequence_element.py
@@ -51,7 +51,7 @@ class SequenceElement(AbstractStackElement):
             self.publish_debug_data('Corresponding debug data', self.current_action._debug_data)
         data = {
             'type': 'sequence',
-            'current': self.current_action.__class__.__name__,
+            'current_action_id': self.current_action_index,
             'content': [elem.repr_dict() for elem in self.actions],
             'debug_data': self._debug_data
         }

--- a/dynamic_stack_decider_visualization/src/dynamic_stack_decider_visualization/dsd_slave.py
+++ b/dynamic_stack_decider_visualization/src/dynamic_stack_decider_visualization/dsd_slave.py
@@ -69,7 +69,7 @@ class DsdSlave(DSD):
             element = parent_element.get_child(remaining_data['activation_reason'])
             element.debug_data = remaining_data['debug_data']
             if remaining_data['type'] == 'sequence':
-                element.current_child = remaining_data['current']
+                element.current_child = remaining_data['current_action_id']
                 self.push(element)
             else:
                 self.push(element)
@@ -140,11 +140,11 @@ class DsdSlave(DSD):
             shape = 'box'
 
             label = ['Sequence:']
-            for e in element.action_elements:
+            for i, e in enumerate(element.action_elements):
                 # Spaces for indentation
                 action_label = '  '
                 # Mark current element (if this sequence is on the stack)
-                if active and e.name == element.current_child:
+                if active and i == element.current_child:
                     action_label += '--> '
                 action_label += e.name
                 if e.parameters:


### PR DESCRIPTION
Currently, multiple sequence elements are highlighted as the current one when they have the same name as the current element. This PR will maybe hopefully bring an end to this madness!