### PR TITLE
Casting all params to the correct type

### DIFF
--- a/dynamic_stack_decider/package.xml
+++ b/dynamic_stack_decider/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>dynamic_stack_decider</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>The bitbots_dsd is an extended form
     of a behaviour state machine. It works like a stack where
     classes describing decisions or actions are pushed on top,

--- a/dynamic_stack_decider/package.xml
+++ b/dynamic_stack_decider/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>dynamic_stack_decider</name>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
   <description>The bitbots_dsd is an extended form
     of a behaviour state machine. It works like a stack where
     classes describing decisions or actions are pushed on top,

--- a/dynamic_stack_decider/src/dynamic_stack_decider/parser.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/parser.py
@@ -146,7 +146,7 @@ class DSDParser:
         for parameter in parameters:
             parameter_key, parameter_value = parameter.split(':')
             if parameter_value.startswith('%'):
-                parameter_value = rospy.get_param(parameter_value[1:])
+                parameter_value = str(rospy.get_param(parameter_value[1:]))
             parameter_dict[parameter_key] = parameter_value
         if token.startswith('$'):
             element = DecisionTreeElement(name, parent, parameter_dict)

--- a/dynamic_stack_decider/src/dynamic_stack_decider/parser.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/parser.py
@@ -1,6 +1,7 @@
 import copy
 import re
 import rospy
+import yaml
 from dynamic_stack_decider.tree import Tree, AbstractTreeElement, DecisionTreeElement, ActionTreeElement, \
     SequenceTreeElement
 
@@ -146,7 +147,9 @@ class DSDParser:
         for parameter in parameters:
             parameter_key, parameter_value = parameter.split(':')
             if parameter_value.startswith('%'):
-                parameter_value = str(rospy.get_param(parameter_value[1:]))
+                parameter_value = rospy.get_param(parameter_value[1:])
+            else:
+                parameter_value = yaml.safe_load(parameter_value)  # universal interpretation of correct datatype
             parameter_dict[parameter_key] = parameter_value
         if token.startswith('$'):
             element = DecisionTreeElement(name, parent, parameter_dict)

--- a/dynamic_stack_decider_visualization/package.xml
+++ b/dynamic_stack_decider_visualization/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>dynamic_stack_decider_visualization</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>
     A Python GUI plugin to visualize the bitbots-dynamic-stack-decider (DSD)
     <br />

--- a/dynamic_stack_decider_visualization/src/dynamic_stack_decider_visualization/dsd_slave.py
+++ b/dynamic_stack_decider_visualization/src/dynamic_stack_decider_visualization/dsd_slave.py
@@ -131,7 +131,7 @@ class DsdSlave(DSD):
             # type: (dict) -> str
             pstr = []
             for pkey, pval in params.items():
-                pstr.append(pkey + ': ' + pval)
+                pstr.append(pkey + ': ' + str(pval))
             pstr = ', '.join(pstr)
             pstr = ' (' + pstr + ')'
             return pstr


### PR DESCRIPTION
## Proposed changes
This casts all ROS params to strings for the visualization (It breaks otherwise). That would remove an issue caused by #30, when using non-string parameter types and the visualization

## Necessary checks
- [x] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

