### PR TITLE
Use inspections instead of string parsing for class discovery

### DIFF
--- a/dynamic_stack_decider/package.xml
+++ b/dynamic_stack_decider/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>dynamic_stack_decider</name>
-  <version>0.3.2</version>
+  <version>0.3.3</version>
   <description>The bitbots_dsd is an extended form
     of a behaviour state machine. It works like a stack where
     classes describing decisions or actions are pushed on top,

--- a/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
@@ -1,9 +1,7 @@
 import importlib
 import inspect
 import json
-import os
 import pkgutil
-import re
 
 import rospy
 from std_msgs.msg import String

--- a/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
@@ -33,6 +33,7 @@ def discover_elements(path):
     for _, modname, _ in pkgutil.walk_packages(path=[path], prefix=base_module + '.'):
         try:
             module = importlib.import_module(modname)
+            # add all classes which are defined directly in the target module (not imported)
             elements.update(inspect.getmembers(module, lambda m: inspect.isclass(m) and inspect.getmodule(m) == module))
         except Exception as e:
             rospy.logerr('Error while loading class {}: {}'.format(modname, e))


### PR DESCRIPTION
## Proposed changes
This pull requests changes the class discovery in the dynamic stack decider to use python inspections instead of string parsing.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

