### PR TITLE
Remove global namespace in locations.yaml

### DIFF
--- a/dynamic_stack_decider_visualization/config/locations.yaml
+++ b/dynamic_stack_decider_visualization/config/locations.yaml
@@ -2,25 +2,25 @@
 locations:
   - display_name: Body Behavior
     package: bitbots_body_behavior
-    debug_topic: /debug/dsd/body_behavior
+    debug_topic: debug/dsd/body_behavior
     relative_action_path: src/bitbots_body_behavior/actions
     relative_decision_path: src/bitbots_body_behavior/decisions
     relative_dsd_path: src/bitbots_body_behavior/main.dsd
   - display_name: Head Behavior
     package: bitbots_head_behavior
-    debug_topic: /debug/dsd/head_behavior
+    debug_topic: debug/dsd/head_behavior
     relative_action_path: src/bitbots_head_behavior/actions
     relative_decision_path: src/bitbots_head_behavior/decisions
     relative_dsd_path: src/bitbots_head_behavior/head_behavior.dsd
   - display_name: HCM
     package: bitbots_hcm
-    debug_topic: /debug/dsd/hcm
+    debug_topic: debug/dsd/hcm
     relative_action_path: src/bitbots_hcm/hcm_dsd/actions
     relative_decision_path: src/bitbots_hcm/hcm_dsd/decisions
     relative_dsd_path: src/bitbots_hcm/hcm_dsd/hcm.dsd
   - display_name: Localization
     package: bitbots_localization
-    debug_topic: /debug/dsd/localization
+    debug_topic: debug/dsd/localization
     relative_action_path: src/bitbots_localization/localization_dsd/actions
     relative_decision_path: src/bitbots_localization/localization_dsd/decisions
     relative_dsd_path: src/bitbots_localization/localization_dsd/localization.dsd


### PR DESCRIPTION
## Proposed changes
Same as all namespace PRs

## Necessary checks
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

