### PR TITLE
mark abstract classes with abc

### DIFF
--- a/dynamic_stack_decider/package.xml
+++ b/dynamic_stack_decider/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>dynamic_stack_decider</name>
-  <version>0.3.3</version>
+  <version>0.3.4</version>
   <description>The bitbots_dsd is an extended form
     of a behaviour state machine. It works like a stack where
     classes describing decisions or actions are pushed on top,

--- a/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
@@ -1,7 +1,8 @@
+from abc import ABCMeta
 from dynamic_stack_decider.abstract_stack_element import AbstractStackElement
 
 
-class AbstractActionElement(AbstractStackElement):
+class AbstractActionElement(AbstractStackElement, metaclass=ABCMeta):
     """
     One action is similar to a state of an FSM.
     As in this case, the system stays in this state in contrast to the decision elements which are called only for determining the active action.

--- a/dynamic_stack_decider/src/dynamic_stack_decider/abstract_decision_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/abstract_decision_element.py
@@ -1,7 +1,8 @@
+from abc import ABCMeta
 from dynamic_stack_decider.abstract_stack_element import AbstractStackElement
 
 
-class AbstractDecisionElement(AbstractStackElement):
+class AbstractDecisionElement(AbstractStackElement, metaclass=ABCMeta):
     """
     The logic is encapsulated in two types of elements.
     The decision elements define the logical path similar to a behavior tree.

--- a/dynamic_stack_decider/src/dynamic_stack_decider/abstract_stack_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/abstract_stack_element.py
@@ -1,8 +1,9 @@
 import rospy
+from abc import ABCMeta, abstractmethod
 from typing import Union
 
 
-class AbstractStackElement(object):
+class AbstractStackElement(metaclass=ABCMeta):
     """
     The AbstractStackElement is the basis of all elements on the stack.
     It provides some help functions which should not be overloaded.
@@ -38,6 +39,7 @@ class AbstractStackElement(object):
         """
         self._dsd.pop()
 
+    @abstractmethod
     def perform(self, reevaluate=False):
         """
         This method is called when the element is on top of the stack.


### PR DESCRIPTION
## Proposed changes
Python subpports marking abstract base classes using the `abc` standard
library. This results in the classes not being instantiable at runtime
as well as creating IDE warnings

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

