### PR TITLE
implement ELSE keyword in dsd language

### DIFF
--- a/dynamic_stack_decider/package.xml
+++ b/dynamic_stack_decider/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>dynamic_stack_decider</name>
-  <version>0.3.5</version>
+  <version>0.4.0</version>
   <description>The bitbots_dsd is an extended form
     of a behaviour state machine. It works like a stack where
     classes describing decisions or actions are pushed on top,

--- a/dynamic_stack_decider/src/dynamic_stack_decider/tree.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/tree.py
@@ -80,7 +80,13 @@ class DecisionTreeElement(AbstractTreeElement):
         if not activating_result:
             # give advice about error
             sys.exit("Decision return was None. You probably forgot to return a string in your perform method.")
-        return self.children[activating_result]
+
+        if activating_result in self.children.keys():
+            return self.children[activating_result]
+        elif "ELSE" in self.children.keys():
+            return self.children["ELSE"]
+        else:
+            return None
 
     def __repr__(self):
         r = '$' + self.name + ' ({}): '.format(self.parameters)

--- a/dynamic_stack_decider/src/dynamic_stack_decider/tree.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/tree.py
@@ -86,7 +86,7 @@ class DecisionTreeElement(AbstractTreeElement):
         elif "ELSE" in self.children.keys():
             return self.children["ELSE"]
         else:
-            return None
+            raise KeyError(f"{activating_result} does not lead to a child of {str(self)} and no ELSE was specified")
 
     def __repr__(self):
         r = '$' + self.name + ' ({}): '.format(self.parameters)


### PR DESCRIPTION
## Proposed changes
The ELSE keyword can be specified as a possible decision result in a
.dsd file. It serves as a catch-all for all non-specified results
values of that decision.

the following example would result in Action2 being executed for every
result of StartDecision that is not SOMETHING
```
-->
$StartDecision
    SOMETHING-->@Action1
    ELSE-->@Action2
```

## Related issues
closes #46 

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

