### PR TITLE
Update CI config and add rdmanifest files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
-@Library('bitbots_jenkins_library') import de.bitbots.jenkins.PackageDefinition
+@Library('bitbots_jenkins_library') import de.bitbots.jenkins.*;
 
-bitbotsPipeline([
-	new PackageDefinition("dynamic_stack_decider", true),
-	new PackageDefinition("dynamic_stack_decider_visualization", true),
-] as PackageDefinition[])
+defineProperties()
+
+def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("dynamic_stack_decider")))
+pipeline.execute()

--- a/dynamic_stack_decider/.rdmanifest
+++ b/dynamic_stack_decider/.rdmanifest
@@ -1,0 +1,14 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/dynamic_stack_decider'
+depends:
+- python3-coverage
+- rospy
+- bitbots_docs
+exec-path: dynamic_stack_decider-master/dynamic_stack_decider
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/dynamic_stack_decider'
+uri: https://github.com/bit-bots/dynamic_stack_decider/archive/refs/heads/master.tar.gz

--- a/dynamic_stack_decider/package.xml
+++ b/dynamic_stack_decider/package.xml
@@ -18,15 +18,14 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <test_depend>python-coverage</test_depend>
-  <doc_depend>python-catkin-pkg</doc_depend>
+  <test_depend>python3-coverage</test_depend>
   <depend>rospy</depend>
   <depend>bitbots_docs</depend>
 
   <export>
     <bitbots_documentation>
       <status>tested_integration</status>
-      <language>python2</language>
+      <language>python3</language>
     </bitbots_documentation>
   </export>
 </package>


### PR DESCRIPTION
## Proposed changes
This PR adds `.rdmanifest` files for dynamic_stack_decider so that it can be installed through rosdep via source.
It also a updates the CI configuration to a newer format so that CI builds this repo again.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

