### PR TITLE
Add parameters for subtrees to the DSD

### DIFF
--- a/dynamic_stack_decider/package.xml
+++ b/dynamic_stack_decider/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>dynamic_stack_decider</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>The bitbots_dsd is an extended form
     of a behaviour state machine. It works like a stack where
     classes describing decisions or actions are pushed on top,

--- a/dynamic_stack_decider/src/dynamic_stack_decider/tree.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/tree.py
@@ -7,6 +7,7 @@ class Tree:
     def __init__(self):
         # The root element of the tree
         self.root_element = None
+        self.parameter_list = []
 
     def set_root_element(self, element):
         """
@@ -56,7 +57,7 @@ class DecisionTreeElement(AbstractTreeElement):
     Children can be added with add_child_element
     """
 
-    def __init__(self, name, parent, parameters=None):
+    def __init__(self, name, parent, parameters=None, unset_parameters=None):
         """
         Create a new DecisionTreeElement
 
@@ -65,7 +66,8 @@ class DecisionTreeElement(AbstractTreeElement):
         :type parent: DecisionTreeElement
         """
         super(DecisionTreeElement, self).__init__(name, parent)
-        self.parameters = parameters
+        self.parameters = parameters or dict()
+        self.unset_parameters = unset_parameters or dict()
 
         # Dictionary that maps results of the decision to the corresponding child
         self.children = dict()
@@ -134,16 +136,18 @@ class ActionTreeElement(AbstractTreeElement):
     parameters that will be passed to the module on creation
     """
 
-    def __init__(self, name, parent, parameters=None):
+    def __init__(self, name, parent, parameters=None, unset_parameters=None):
         """
         Create a new ActionTreeElement
         :param name: the class name of the corresponding AbstractActionElement
         :param parent: the parent element
         :type parent: DecisionTreeElement
         :param parameters: A dictionary of parameters
+        :param unset_parameters: A dictionary of parameters that must be set later
         """
         super(ActionTreeElement, self).__init__(name, parent)
-        self.parameters = parameters
+        self.parameters = parameters or dict()
+        self.unset_parameters = unset_parameters or dict()
         self.in_sequence = False
 
     def __repr__(self):

--- a/dynamic_stack_decider/tests/test.dsd
+++ b/dynamic_stack_decider/tests/test.dsd
@@ -8,6 +8,15 @@ $ThirdDecision
     FIRST --> @FirstAction
     SECOND --> @SecondAction
 
+#ParameterSubBehavior + key1 + key2
+$ThirdDecision
+    FIRST --> @FirstAction + key:*key1
+    SECOND --> @SecondAction + key:*key2
+
+#NestedParameterSubBehavior + key_nested1 + key_nested2
+$ThirdDecision
+    FIRST --> #ParameterSubBehavior + key1:*key_nested1 + key2:*key_nested2
+
 -->TestDSD
 $FirstDecision
     ACTION --> @FirstAction
@@ -17,6 +26,8 @@ $FirstDecision
     SUBBEHAVIOR --> #SubBehavior
     SEQUENCE --> @FirstAction, @SecondAction
     PARAMETERS --> @FirstAction + key:value
+    PARAMETER_DECISION --> $FirstDecision + key:value
+        FIRST --> @FirstAction
     LINE_COMMENT --> @FirstAction // Comment at end of line
     // This tests a single line comment and should be ignored
     //** This tests a
@@ -29,3 +40,5 @@ $FirstDecision
     MULTIPLE_PARAMETERS --> @FirstAction + key1:value1 + key2:value2
     SECOND_SUBBEHAVIOR_1 --> #SecondSubBehavior
     SECOND_SUBBEHAVIOR_2 --> #SecondSubBehavior
+    PARAMETER_SUBBEHAVIOR --> #ParameterSubBehavior + key2:value2 + key1:value1
+    NESTED_PARAMETER_SUBBEHAVIOR --> #NestedParameterSubBehavior + key_nested2:nested2 + key_nested1:nested1

--- a/dynamic_stack_decider/tests/test_parser.py
+++ b/dynamic_stack_decider/tests/test_parser.py
@@ -18,7 +18,8 @@ class ParserTest(unittest.TestCase):
         self.assertSetEqual(set(self.tree.root_element.children.keys()),
                             {'ACTION', 'DECISION', 'SUBBEHAVIOR', 'SEQUENCE', 'PARAMETERS',
                              'LINE_COMMENT', 'BLOCK_COMMENT', 'COMPLICATED_COMMENT',
-                             'MULTIPLE_PARAMETERS', 'SECOND_SUBBEHAVIOR_1', 'SECOND_SUBBEHAVIOR_2'})
+                             'MULTIPLE_PARAMETERS', 'SECOND_SUBBEHAVIOR_1', 'SECOND_SUBBEHAVIOR_2',
+                             'PARAMETER_DECISION', 'PARAMETER_SUBBEHAVIOR', 'NESTED_PARAMETER_SUBBEHAVIOR'})
 
     def test_following_elements(self):
         first_child = self.tree.root_element.get_child('ACTION')
@@ -58,10 +59,16 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(second_action.name, 'SecondAction')
         self.assertTrue(isinstance(second_action, ActionTreeElement))
 
-    def test_parameters(self):
+    def test_action_parameters(self):
         parameter_element = self.tree.root_element.get_child('PARAMETERS')
         self.assertEqual(parameter_element.name, 'FirstAction')
         self.assertTrue(isinstance(parameter_element, ActionTreeElement))
+        self.assertDictEqual(parameter_element.parameters, {'key': 'value'})
+
+    def test_decision_parameters(self):
+        parameter_element = self.tree.root_element.get_child('PARAMETER_DECISION')
+        self.assertEqual(parameter_element.name, 'FirstDecision')
+        self.assertTrue(isinstance(parameter_element, DecisionTreeElement))
         self.assertDictEqual(parameter_element.parameters, {'key': 'value'})
 
     def test_line_comment(self):
@@ -93,6 +100,21 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(sub_behavior_1_root_decision.name, sub_behavior_2_root_decision.name)
         self.assertEqual(sub_behavior_1_root_decision.activation_reason, 'SECOND_SUBBEHAVIOR_1')
         self.assertEqual(sub_behavior_2_root_decision.activation_reason, 'SECOND_SUBBEHAVIOR_2')
+
+    def test_parameter_subbehavior(self):
+        parameter_subbehavior_decision = self.tree.root_element.get_child('PARAMETER_SUBBEHAVIOR')
+        first_action = parameter_subbehavior_decision.get_child('FIRST')
+        self.assertEqual(first_action.parameters, {'key': 'value1'})
+        second_action = parameter_subbehavior_decision.get_child('SECOND')
+        self.assertEqual(second_action.parameters, {'key': 'value2'})
+
+    def test_nested_parameter_subbehavior(self):
+        subbehavior_decision = self.tree.root_element.get_child('NESTED_PARAMETER_SUBBEHAVIOR')
+        inner_subbehavior_decision = subbehavior_decision.get_child('FIRST')
+        first_action = inner_subbehavior_decision.get_child('FIRST')
+        self.assertEqual(first_action.parameters, {'key': 'nested1'})
+        second_action = inner_subbehavior_decision.get_child('SECOND')
+        self.assertEqual(second_action.parameters, {'key': 'nested2'})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Proposed changes
This pull request adds parameters to subtrees. The syntax when calling the subtree is the same as for parameters for actions and decisions. Inside a subtree, the parameters can be used with the `*` operator. For an example, take a look at the test.
I am fairly sure that everything is working as expected because the tests are passing.

## Related issues
Closes #43.

## Necessary checks
- [x] Increase the package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

