### PR TITLE
Fix reevaluate with ELSE keyword

### DIFF
--- a/dynamic_stack_decider/package.xml
+++ b/dynamic_stack_decider/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>dynamic_stack_decider</name>
-  <version>0.5.2</version>
+  <version>0.5.3</version>
   <description>The bitbots_dsd is an extended form
     of a behaviour state machine. It works like a stack where
     classes describing decisions or actions are pushed on top,


### PR DESCRIPTION
## Proposed changes
In #47, a bug was introduced that when the ELSE keyword was chosen in a decision that was reevaluated, the reevaluation always detected a decision change, i.e. the stack was discarded.

## Necessary checks
- [x] Update package version
- [ ] Run `catkin build`
- [x] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board