### PR TITLE
only publish debug when subscriber

### DIFF
--- a/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
@@ -292,7 +292,7 @@ class DSD:
         Helper method to publish debug data
         """
 
-        if self.debug_active:
+        if self.debug_active and self.debug_publisher.get_num_connections() != 0:
             # Construct JSON encodable object which represents the current stack
             data = None
             for tree_elem, elem_instance in reversed(self.stack):


### PR DESCRIPTION
## Proposed changes
Currently we are publishing a lot of unnecessary debug. This minimizes it

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

