### PR TITLE
Add dsd params which deactivate the stack reevaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ When the element is reevaluated, `perform` is called on the element.
 If the result of `perform` is the same as the last time it was called, nothing happens and the next decision is reevaluated.
 If the result of `perform` is different from the last time, everything above the reevaluated decision is discarded and a new element, depending on the result of `perform`, is pushed on the stack and executed.
 
-An action can call `self.do_not_reevaluate()` to avoid reevaluation of the stack on the next call to `update`. 
+An action can call `self.do_not_reevaluate()` to avoid reevaluation of the stack on the next call to `update`. Alternatively the parameters (see #Parameters) `r` or `reevaluate` can be used in the dsd file to enable or disable the reevaluation during a specific action. 
 
 ## Sequence elements
 

--- a/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
@@ -14,7 +14,7 @@ class AbstractActionElement(AbstractStackElement, metaclass=ABCMeta):
     """
     def __init__(self, blackboard, dsd, parameters):
         """
-        Konstructor of the action element
+        Constructor of the action element
         :param blackboard: Shared blackboard for data exchange between elements
         :param dsd: The stack decider which has this element on its stack.
         :param parameters: Optional parameters which serve as arguments to this element

--- a/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
@@ -21,7 +21,8 @@ class AbstractActionElement(AbstractStackElement, metaclass=ABCMeta):
         """
         super().__init__(blackboard, dsd, parameters)
         # Reevaluation can be disabled by setting 'r' or 'reevaluate' to False
-        self.never_reevaluate = not parameters.get('r', True) or not parameters.get('reevaluate', True)
+        if parameters is not None:
+            self.never_reevaluate = not parameters.get('r', True) or not parameters.get('reevaluate', True)
 
 
     def do_not_reevaluate(self):

--- a/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
@@ -12,6 +12,17 @@ class AbstractActionElement(AbstractStackElement, metaclass=ABCMeta):
     Actions do not push further elements on the stack but command actions on lower-level modules like new movement goals.
     If the action is complete, it can remove itself from the stack by performing a pop command.
     """
+    def __init__(self, blackboard, dsd, parameters):
+        """
+        Konstructor of the action element
+        :param blackboard: Shared blackboard for data exchange between elements
+        :param dsd: The stack decider which has this element on its stack.
+        :param parameters: Optional parameters which serve as arguments to this element
+        """
+        super().__init__(blackboard, dsd, parameters)
+        # Reevaluation can be disabled by setting 'r' or 'reevaluate' to False
+        self.never_reevaluate = not parameters.get('r', True) or not parameters.get('reevaluate', True)
+
 
     def do_not_reevaluate(self):
         """

--- a/dynamic_stack_decider/src/dynamic_stack_decider/abstract_stack_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/abstract_stack_element.py
@@ -27,6 +27,7 @@ class AbstractStackElement(metaclass=ABCMeta):
 
         self._dsd = dsd
         self.blackboard = blackboard
+        self.never_reevaluate = False
 
     def pop(self):
         """

--- a/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
@@ -225,11 +225,15 @@ class DSD:
                         return
                 self.stack_exec_index += 1
             self.stack_reevaluate = False
+        # Get the top module
+        current_tree_element, current_instance = self.stack[-1]
         if reevaluate:
             # reset flag
             self.do_not_reevaluate = False
-        # run the top module
-        current_tree_element, current_instance = self.stack[-1]
+        if current_instance.never_reevaluate:
+            # Deactivate reevaluation if action had never_reevaluate flag
+            self.do_not_reevaluate = True
+        # Run the top module
         result = current_instance.perform()
         if isinstance(current_instance, AbstractDecisionElement):
             self.push(current_tree_element.get_child(result))


### PR DESCRIPTION
## Proposed changes
An action prohibits the reevaluation if the parameter `r` or `reevaluate` is set to false in the DSD file.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

