### PR TITLE
Fix do not reevaluate for sequences

### DIFF
--- a/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/abstract_action_element.py
@@ -23,7 +23,8 @@ class AbstractActionElement(AbstractStackElement, metaclass=ABCMeta):
         # Reevaluation can be disabled by setting 'r' or 'reevaluate' to False
         if parameters is not None:
             self.never_reevaluate = not parameters.get('r', True) or not parameters.get('reevaluate', True)
-
+        else:
+            self.never_reevaluate = False
 
     def do_not_reevaluate(self):
         """

--- a/dynamic_stack_decider/src/dynamic_stack_decider/abstract_stack_element.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/abstract_stack_element.py
@@ -27,7 +27,6 @@ class AbstractStackElement(metaclass=ABCMeta):
 
         self._dsd = dsd
         self.blackboard = blackboard
-        self.never_reevaluate = False
 
     def pop(self):
         """

--- a/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/dsd.py
@@ -230,9 +230,10 @@ class DSD:
         if reevaluate:
             # reset flag
             self.do_not_reevaluate = False
-        if current_instance.never_reevaluate:
+        if (isinstance(current_instance, AbstractActionElement) and current_instance.never_reevaluate or
+                isinstance(current_instance, SequenceElement) and current_instance.current_action.never_reevaluate):
             # Deactivate reevaluation if action had never_reevaluate flag
-            self.do_not_reevaluate = True
+            self.set_do_not_reevaluate()
         # Run the top module
         result = current_instance.perform()
         if isinstance(current_instance, AbstractDecisionElement):


### PR DESCRIPTION
## Proposed changes
The never_reevaluate flag introduced in #62 was not working correctly for action sequences. This pull request fixes the issue.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

