### PR TITLE
Add error for spaces in parameter values

### DIFF
--- a/dynamic_stack_decider/src/dynamic_stack_decider/parser.py
+++ b/dynamic_stack_decider/src/dynamic_stack_decider/parser.py
@@ -192,6 +192,10 @@ def _extract_parameters(token, lnr):
         except ValueError:
             raise ParseError('Error parsing line {}: Invalid parameter list'.format(lnr))
 
+        if ' ' in parameter_value:
+            raise ParseError('Error parsing line {}: Parameter values should not contain spaces. '
+                             'Did you forget a comma?'.format(lnr))
+
         if parameter_value.startswith('%'):
             parameter_value = rospy.get_param(parameter_value[1:])
             parameter_dict[parameter_key] = parameter_value


### PR DESCRIPTION
## Proposed changes
Technically, spaces in parameter values are absolutely possible. However, more often than not, the issue is that a comma has been forgotten in a sequence element. Therefore this error was added.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

