### PR TITLE
Fix bitbots_docs dependency

### DIFF
--- a/dynamic_stack_decider_visualization/package.xml
+++ b/dynamic_stack_decider_visualization/package.xml
@@ -23,10 +23,11 @@
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>dynamic_stack_decider</exec_depend>
+
+  <depend>bitbots_docs</depend>
   <depend>python3-yaml</depend>
   <depend>python3-pydot</depend>
 
-  <doc_depend>bitbots_docs</doc_depend>
 
   <export>
     <architecture_independent/>


### PR DESCRIPTION
When compiling this package alone, bitbots_docs does not get compiled before which leads to missing dependency errors in CMake

## Related issues
Similar to https://github.com/bit-bots/bitbots_navigation/pull/204