### PR TITLE
Fix path to tests in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you use VSCode, you can use the [DSD extension](https://marketplace.visualstu
 Here are a few projects that use the DSD and can be used for reference:
 * The [Bit-Bots Body Behavior](https://github.com/bit-bots/bitbots_behavior/tree/master/bitbots_body_behavior/bitbots_body_behavior)
 * The [Bit-Bots Humanoid Control Module](https://github.com/bit-bots/bitbots_motion/tree/master/bitbots_hcm/bitbots_hcm/hcm_dsd)
-* The [Parser Test](https://github.com/bit-bots/dynamic_stack_decider/tree/master/dynamic_stack_decider/tests) in this repository
+* The [Parser Test](https://github.com/bit-bots/dynamic_stack_decider/tree/master/dynamic_stack_decider/test) in this repository
 
 ## The Paper
 


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->

`tests` was recently renamed to `test` due to us using the ROS 2 testing setup. I forgot to change a link in the readme.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
This PR 

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [x] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] This PR is on our `Software` project board
