### PR TITLE
Downgrade black, fix removed imports from __init__.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         - "--fix"
         - "--exit-non-zero-on-fix"
 - repo: https://github.com/psf/black
-  rev: 23.11.0
+  rev: 23.10.0  # keep this version for Ubuntu support
   hooks:
     - id: black
 - repo: https://github.com/pocc/pre-commit-hooks

--- a/dynamic_stack_decider/dynamic_stack_decider/__init__.py
+++ b/dynamic_stack_decider/dynamic_stack_decider/__init__.py
@@ -1,0 +1,5 @@
+from .abstract_action_element import AbstractActionElement
+from .abstract_decision_element import AbstractDecisionElement
+from .dsd import DSD
+
+__all__ = [DSD, AbstractDecisionElement, AbstractActionElement]


### PR DESCRIPTION
* Unused imports were removed but are required for better import from other packages. This PR changes it to use `__all__` convention
* Downgrade black for Ubuntu's pre-commit version (https://github.com/psf/black/pull/3940 is not supported, wait until Ubuntu updates pre-commit or https://github.com/psf/black/pull/4041 is merged)