### PR TITLE
Use PyQt5 for GUI

### DIFF
--- a/dynamic_stack_decider_visualization/dynamic_stack_decider_visualization/dsd_follower.py
+++ b/dynamic_stack_decider_visualization/dynamic_stack_decider_visualization/dsd_follower.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Optional, Union
 
 import pydot
-from python_qt_binding.QtGui import QStandardItem, QStandardItemModel
+from PyQt5.QtGui import QStandardItem, QStandardItemModel
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from std_msgs.msg import String
@@ -254,9 +254,6 @@ class DsdFollower:
     ):
         """
         Appends debug_data of a given element and its children to a QStandardItem.
-
-        :type parent_item: python_qt_binding.QtGui.QStandardItem
-        :type debug_data: dict or list or int or float or str or bool
         """
         if isinstance(debug_data, list):
             for i, data in enumerate(debug_data):

--- a/dynamic_stack_decider_visualization/dynamic_stack_decider_visualization/dsd_visualization_plugin.py
+++ b/dynamic_stack_decider_visualization/dynamic_stack_decider_visualization/dsd_visualization_plugin.py
@@ -35,11 +35,11 @@ from typing import Optional
 
 import pydot
 from ament_index_python import get_package_share_directory
-from python_qt_binding import loadUi
-from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtGui import QIcon, QPainter, QStandardItemModel
-from python_qt_binding.QtSvg import QSvgGenerator
-from python_qt_binding.QtWidgets import QFileDialog, QGraphicsScene, QWidget
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QIcon, QPainter, QStandardItemModel
+from PyQt5.QtSvg import QSvgGenerator
+from PyQt5.QtWidgets import QFileDialog, QGraphicsScene, QWidget
+from PyQt5.uic import loadUi
 from qt_dotgraph.dot_to_qt import DotToQtGenerator
 from qt_dotgraph.pydotfactory import PydotFactory
 from rclpy.node import Node

--- a/dynamic_stack_decider_visualization/dynamic_stack_decider_visualization/interactive_graphics_view.py
+++ b/dynamic_stack_decider_visualization/dynamic_stack_decider_visualization/interactive_graphics_view.py
@@ -29,9 +29,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-from python_qt_binding.QtCore import QPointF, QRectF, Qt
-from python_qt_binding.QtGui import QTransform
-from python_qt_binding.QtWidgets import QGraphicsView
+from PyQt5.QtCore import QPointF, QRectF, Qt
+from PyQt5.QtGui import QTransform
+from PyQt5.QtWidgets import QGraphicsView
 
 
 # ruff: noqa: N802

--- a/dynamic_stack_decider_visualization/package.xml
+++ b/dynamic_stack_decider_visualization/package.xml
@@ -15,14 +15,13 @@
 
   <license>MIT</license>
 
-  <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
-  <exec_depend>python_qt_binding</exec_depend>
-  <exec_depend>qt_dotgraph</exec_depend>
-  <exec_depend>rosgraph_msgs</exec_depend>
-  <exec_depend>rclpy</exec_depend>
-  <exec_depend>rqt_gui</exec_depend>
-  <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>dynamic_stack_decider</exec_depend>
+  <exec_depend>python3-pyqt5</exec_depend>
+  <exec_depend>qt_dotgraph</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rosgraph_msgs</exec_depend>
+  <exec_depend>rqt_gui_py</exec_depend>
+  <exec_depend>rqt_gui</exec_depend>
 
   <depend>python3-pydot</depend>
 


### PR DESCRIPTION
This enables type support for GUI components and relies on a commonly used QT wrapper instead of some ROS specific hacky one that is currently being deprecated. 

Only imports change.
