### PR TITLE
Configure `pytest` testing for vizualization

### DIFF
--- a/dynamic_stack_decider/package.xml
+++ b/dynamic_stack_decider/package.xml
@@ -24,6 +24,7 @@
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>python3-yaml</depend>
+  <test_depend>python3-pytest</test_depend>
   <test_depend>python3-coverage</test_depend>
 
   <export>

--- a/dynamic_stack_decider_visualization/package.xml
+++ b/dynamic_stack_decider_visualization/package.xml
@@ -25,6 +25,7 @@
 
   <depend>python3-pydot</depend>
 
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <architecture_independent/>

--- a/dynamic_stack_decider_visualization/setup.py
+++ b/dynamic_stack_decider_visualization/setup.py
@@ -12,6 +12,7 @@ setup(
         ("share/" + package_name, ["plugin.xml"]),
     ],
     install_requires=["setuptools"],
+    tests_require=["pytest"],
     zip_safe=True,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
to ensure that the CI `colcon test` run works, because with a change to
python 3.12 the `unittest` standard library used by default with colcon
now exits with an error code of 5 for an empty test suite.

## Related issues

See: https://github.com/colcon/colcon-core/issues/678
See: https://github.com/python/cpython/pull/102051

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [ ] This PR is on our `Software` project board
